### PR TITLE
Error validation for retrieving invalid teams

### DIFF
--- a/db/dynamodb.py
+++ b/db/dynamodb.py
@@ -158,7 +158,7 @@ class DynamoDB:
     def retrieve_team(self, team_name):
         """
         Retrieve team from teams table.
-        
+
         :param: team_name: used as key for retrieving team objects.
         :raise: raises a LookupError if team id is not found.
         :return: the team object if team_name is found.

--- a/db/dynamodb.py
+++ b/db/dynamodb.py
@@ -159,9 +159,8 @@ class DynamoDB:
         """
         Retrieve team from teams table.
 
-        :param team_name:
         :raise: raises a LookupError if team id is not found.
-        :return:
+        :return: the team object if team_name is found
         """
         team_table = self.ddb.Table('teams')
         response = team_table.get_item(
@@ -170,7 +169,7 @@ class DynamoDB:
                 'github_team_name': team_name
             }
         )
-        if('Item' in response.keys()):
+        if'Item' in response.keys():
             return self.team_from_dict(response['Item'])
         else:
             raise LookupError('Team "{}" not found'.format(team_name))

--- a/db/dynamodb.py
+++ b/db/dynamodb.py
@@ -158,9 +158,10 @@ class DynamoDB:
     def retrieve_team(self, team_name):
         """
         Retrieve team from teams table.
-
+        
+        :param: team_name: used as key for retrieving team objects.
         :raise: raises a LookupError if team id is not found.
-        :return: the team object if team_name is found
+        :return: the team object if team_name is found.
         """
         team_table = self.ddb.Table('teams')
         response = team_table.get_item(
@@ -169,7 +170,7 @@ class DynamoDB:
                 'github_team_name': team_name
             }
         )
-        if'Item' in response.keys():
+        if 'Item' in response.keys():
             return self.team_from_dict(response['Item'])
         else:
             raise LookupError('Team "{}" not found'.format(team_name))

--- a/db/dynamodb.py
+++ b/db/dynamodb.py
@@ -160,6 +160,7 @@ class DynamoDB:
         Retrieve team from teams table.
 
         :param team_name:
+        :raise: raises a LookupError if team id is not found.
         :return:
         """
         team_table = self.ddb.Table('teams')
@@ -169,8 +170,10 @@ class DynamoDB:
                 'github_team_name': team_name
             }
         )
-
-        return self.team_from_dict(response['Item'])
+        if('Item' in response.keys()):
+            return self.team_from_dict(response['Item'])
+        else:
+            raise LookupError('Team "{}" not found'.format(team_name))
 
     @staticmethod
     def team_from_dict(d):

--- a/tests/db/dynamodb_test.py
+++ b/tests/db/dynamodb_test.py
@@ -54,6 +54,18 @@ def test_query_user():
 
 
 @pytest.mark.db
+def test_retrieve_invalid_team():
+    """Test to see if we can retrieve invalid team."""
+    ddb = DynamoDB()
+    try:
+        team = ddb.retrieve_team('rocket2.0')
+
+        assert False
+    except LookupError as e:
+        assert str(e) == 'Team "{}" not found'.format('rocket2.0')
+
+
+@pytest.mark.db
 def test_store_retrieve_team():
     """Test to see if we can store and retrieve the same team."""
     ddb = DynamoDB()


### PR DESCRIPTION
# Pull Request

## Description
Added retrieving invalid teams test and implemented error handling if an invalid team is attempted to be retrieved. 

## Testing
run `pytest -m db`

## Ticket(s)

Closes #83 
