### PR TITLE
#64 user command database implementation

### DIFF
--- a/command/core.py
+++ b/command/core.py
@@ -5,15 +5,18 @@ from command.commands.user import UserCommand
 class Core:
     """Encapsulate methods for handling events."""
 
-    def __init__(self):
+    def __init__(self, DBfacade, bot):
         """Initialize the dictionary of command handlers."""
         self.__commands = {}
-        self.__commands["user"] = UserCommand()
+        self._facade = DBfacade
+        self.__bot = bot
+        self.__commands["user"] = UserCommand(self._facade, self.__bot)
 
     def handle_app_mention(self, event_data):
         """Handle the events associated with mentions of @rocket."""
         message = event_data["event"]["text"]
         user = event_data["event"]["user"]
+        channel = event_data["event"]["channel"]
         s = message.split(' ', 2)
         if s[0] != "@rocket":
             return 0
@@ -21,7 +24,7 @@ class Core:
             command_type = s[1]
             command = command_type + ' ' + s[2]
             try:
-                self.__commands[command_type].handle(command, user)
+                self.__commands[command_type].handle(command, user, channel)
                 return 1
             except KeyError:
                 return -1

--- a/command/core.py
+++ b/command/core.py
@@ -5,12 +5,12 @@ from command.commands.user import UserCommand
 class Core:
     """Encapsulate methods for handling events."""
 
-    def __init__(self, DBfacade, bot):
+    def __init__(self, db_facade, bot):
         """Initialize the dictionary of command handlers."""
         self.__commands = {}
-        self._facade = DBfacade
+        self.__facade = db_facade
         self.__bot = bot
-        self.__commands["user"] = UserCommand(self._facade, self.__bot)
+        self.__commands["user"] = UserCommand(self.__facade, self.__bot)
 
     def handle_app_mention(self, event_data):
         """Handle the events associated with mentions of @rocket."""

--- a/tests/command/commands/user_test.py
+++ b/tests/command/commands/user_test.py
@@ -1,174 +1,141 @@
 """Test user command parsing."""
 from command.commands.user import UserCommand
-from unittest import mock
+from unittest import mock, TestCase
 from model.user import User
 from db.facade import DBFacade
 from model.permissions import Permissions
 from bot.bot import Bot
 
 
-def test_get_command_name():
-    """Test user command get_name method."""
-    mock_facade = mock.MagicMock(DBFacade)
-    mock_bot = mock.MagicMock(Bot)
-    testcommand = UserCommand(mock_facade, mock_bot)
-    assert testcommand.get_name() == "user"
+class TestUserCommand(TestCase):
+    """Test Case for UserCommand class."""
 
+    def setUp(self):
+        """Set up the test case environment."""
+        self.mock_facade = mock.MagicMock(DBFacade)
+        self.mock_bot = mock.MagicMock(Bot)
+        self.testcommand = UserCommand(self.mock_facade, self.mock_bot)
 
-def test_get_help():
-    """Test user command get_help method."""
-    mock_facade = mock.MagicMock(DBFacade)
-    mock_bot = mock.MagicMock(Bot)
-    testcommand = UserCommand(mock_facade, mock_bot)
-    assert testcommand.get_help() == UserCommand.help
+    def test_get_command_name(self):
+        """Test user command get_name method."""
+        assert self.testcommand.get_name() == "user"
 
+    def test_get_help(self):
+        """Test user command get_help method."""
+        assert self.testcommand.get_help() == UserCommand.help
 
-def test_handle_nosubs():
-    """Test user with no sub-parsers."""
-    mock_facade = mock.MagicMock(DBFacade)
-    mock_bot = mock.MagicMock(Bot)
-    testcommand = UserCommand(mock_facade, mock_bot)
-    testcommand.handle('user', "U0G9QF9C6", "C0LAN2Q65")
-    mock_bot.send_to_channel.\
-        assert_called_once_with(UserCommand.help, "C0LAN2Q65")
+    def test_handle_nosubs(self):
+        """Test user with no sub-parsers."""
+        self.testcommand.handle('user', "U0G9QF9C6", "C0LAN2Q65")
+        self.mock_bot.send_to_channel.\
+            assert_called_once_with(UserCommand.help, "C0LAN2Q65")
 
+    def test_handle_bad_args(self):
+        """Test user with invalid arguments."""
+        self.testcommand.handle('user geese', "U0G9QF9C6", "C0LAN2Q65")
+        self.mock_bot.send_to_channel.\
+            assert_called_once_with(UserCommand.help, "C0LAN2Q65")
 
-def test_handle_bad_args():
-    """Test user with invalid arguments."""
-    mock_facade = mock.MagicMock(DBFacade)
-    mock_bot = mock.MagicMock(Bot)
-    testcommand = UserCommand(mock_facade, mock_bot)
-    testcommand.handle('user geese', "U0G9QF9C6", "C0LAN2Q65")
-    mock_bot.send_to_channel.\
-        assert_called_once_with(UserCommand.help, "C0LAN2Q65")
+    def test_handle_bad_optional_args(self):
+        """Test user edit with invalid optional arguments."""
+        self.testcommand.handle('user edit --biology stuff',
+                                "U0G9QF9C6", "C0LAN2Q65")
+        self.mock_bot.send_to_channel.\
+            assert_called_once_with(UserCommand.help, "C0LAN2Q65")
 
+    def test_handle_view(self):
+        """Test user command view parser and handle method."""
+        user_id = "U0G9QF9C6"
+        user = User(user_id)
+        self.mock_facade.retrieve_user.return_value = user
+        self.testcommand.handle('user view', user_id, "C0LAN2Q65")
+        self.mock_facade.retrieve_user.assert_called_once_with("U0G9QF9C6")
+        self.mock_bot.send_to_channel.\
+            assert_called_once_with(str(user), "C0LAN2Q65")
 
-def test_handle_bad_optional_args():
-    """Test user edit with invalid optional arguments."""
-    mock_facade = mock.MagicMock(DBFacade)
-    mock_bot = mock.MagicMock(Bot)
-    testcommand = UserCommand(mock_facade, mock_bot)
-    testcommand.handle('user edit --biology stuff', "U0G9QF9C6", "C0LAN2Q65")
-    mock_bot.send_to_channel.\
-        assert_called_once_with(UserCommand.help, "C0LAN2Q65")
+    def test_handle_view_other_user(self):
+        """Test user command view handle with slack_id parameter."""
+        user_id = "U0G9QF9C6"
+        user = User("ABCDE8FA9")
+        self.mock_facade.retrieve_user.return_value = user
+        self.testcommand.handle('user view --slack_id ABCDE8FA9',
+                                user_id, "C0LAN2Q65")
+        self.mock_facade.retrieve_user.\
+            assert_called_once_with("ABCDE8FA9")
+        self.mock_bot.send_to_channel.\
+            assert_called_once_with(str(user), "C0LAN2Q65")
 
+    def test_handle_view_lookup_error(self):
+        """Test user command view handle with user not in database."""
+        user_id = "U0G9QF9C6"
+        self.mock_facade.retrieve_user.side_effect = LookupError
+        self.testcommand.handle('user view --slack_id ABCDE8FA9',
+                                user_id, "C0LAN2Q65")
+        self.mock_facade.retrieve_user.assert_called_once_with("ABCDE8FA9")
+        self.mock_bot.send_to_channel.\
+            assert_called_once_with(UserCommand.lookup_error, "C0LAN2Q65")
 
-def test_handle_view():
-    """Test user command view parser and handle method."""
-    mock_facade = mock.MagicMock(DBFacade)
-    user_id = "U0G9QF9C6"
-    user = User(user_id)
-    mock_bot = mock.MagicMock(Bot)
-    mock_facade.retrieve_user.return_value = user
-    testcommand = UserCommand(mock_facade, mock_bot)
-    testcommand.handle('user view', user_id, "C0LAN2Q65")
-    mock_facade.retrieve_user.assert_called_once_with("U0G9QF9C6")
-    mock_bot.send_to_channel.assert_called_once_with(str(user), "C0LAN2Q65")
+    def test_handle_help(self):
+        """Test user command help parser."""
+        self.testcommand.handle('user help', "U0G9QF9C6", "C0LAN2Q65")
+        self.mock_bot.send_to_channel.\
+            assert_called_once_with(UserCommand.help, "C0LAN2Q65")
 
+    def test_handle_delete(self):
+        """Test user command delete parser."""
+        user = User("ABCDEFG2F")
+        user.set_permissions_level(Permissions.admin)
+        self.mock_facade.retrieve_user.return_value = user
+        message = "Deleted user with Slack ID: " + "U0G9QF9C6"
+        self.testcommand.handle("user delete U0G9QF9C6",
+                                "ABCDEFG2F", "C0LAN2Q65")
+        self.mock_facade.retrieve_user.assert_called_once_with("ABCDEFG2F")
+        self.mock_facade.delete_user.assert_called_once_with("U0G9QF9C6")
+        self.mock_bot.send_to_channel.\
+            assert_called_once_with(message, "C0LAN2Q65")
 
-def test_handle_view_other_user():
-    """Test user command view handle with slack_id parameter."""
-    mock_facade = mock.MagicMock(DBFacade)
-    user_id = "U0G9QF9C6"
-    user = User("ABCDE8FA9")
-    mock_bot = mock.MagicMock(Bot)
-    mock_facade.retrieve_user.return_value = user
-    testcommand = UserCommand(mock_facade, mock_bot)
-    testcommand.handle('user view --slack_id ABCDE8FA9', user_id, "C0LAN2Q65")
-    mock_facade.retrieve_user.assert_called_once_with("ABCDE8FA9")
-    mock_bot.send_to_channel.assert_called_once_with(str(user), "C0LAN2Q65")
+    def test_handle_delete_not_admin(self):
+        """Test user command delete where user is not admin."""
+        user = User("ABCDEFG2F")
+        user.set_permissions_level(Permissions.member)
+        self.mock_facade.retrieve_user.return_value = user
+        self.testcommand.handle("user delete U0G9QF9C6",
+                                "ABCDEFG2F", "C0LAN2Q65")
+        self.mock_facade.retrieve_user.assert_called_once_with("ABCDEFG2F")
+        message = "You do not have the sufficient " \
+                  "permission level for this command!"
+        self.mock_bot.send_to_channel.\
+            assert_called_once_with(message, "C0LAN2Q65")
+        self.mock_facade.delete_user.assert_not_called()
 
+    def test_handle_delete_lookup_error(self):
+        """Test user command delete parser."""
+        user = User("ABCDEFG2F")
+        user.set_permissions_level(Permissions.admin)
+        self.mock_facade.retrieve_user.return_value = user
+        self.mock_facade.delete_user.side_effect = LookupError
+        self.testcommand.handle("user delete U0G9QF9C6",
+                                "ABCDEFG2F", "C0LAN2Q65")
+        self.mock_facade.retrieve_user.assert_called_once_with("ABCDEFG2F")
+        self.mock_facade.delete_user.assert_called_once_with("U0G9QF9C6")
+        self.mock_bot.send_to_channel.\
+            assert_called_once_with(UserCommand.lookup_error, "C0LAN2Q65")
 
-def test_handle_view_lookup_error():
-    """Test user command view handle with user not in database."""
-    mock_facade = mock.MagicMock(DBFacade)
-    user_id = "U0G9QF9C6"
-    mock_bot = mock.MagicMock(Bot)
-    mock_facade.retrieve_user.side_effect = LookupError
-    testcommand = UserCommand(mock_facade, mock_bot)
-    testcommand.handle('user view --slack_id ABCDE8FA9', user_id, "C0LAN2Q65")
-    mock_facade.retrieve_user.assert_called_once_with("ABCDE8FA9")
-    mock_bot.send_to_channel.\
-        assert_called_once_with(UserCommand.lookup_error, "C0LAN2Q65")
+    def test_handle_edit_name(self):
+        """Test user command edit parser with one field."""
+        assert self.testcommand.handle("user edit --name rob", "U0G9QF9C6",
+                                       "C0LAN2Q65") == \
+            "user edited: name: rob, "
 
-
-def test_handle_help():
-    """Test user command help parser."""
-    mock_facade = mock.MagicMock(DBFacade)
-    mock_bot = mock.MagicMock(Bot)
-    testcommand = UserCommand(mock_facade, mock_bot)
-    testcommand.handle('user help', "U0G9QF9C6", "C0LAN2Q65")
-    mock_bot.send_to_channel.\
-        assert_called_once_with(UserCommand.help, "C0LAN2Q65")
-
-
-def test_handle_delete():
-    """Test user command delete parser."""
-    mock_bot = mock.MagicMock(Bot)
-    mock_facade = mock.MagicMock(DBFacade)
-    testcommand = UserCommand(mock_facade, mock_bot)
-    user = User("ABCDEFG2F")
-    user.set_permissions_level(Permissions.admin)
-    mock_facade.retrieve_user.return_value = user
-    message = "Deleted user with Slack ID: " + "U0G9QF9C6"
-    testcommand.handle("user delete U0G9QF9C6", "ABCDEFG2F", "C0LAN2Q65")
-    mock_facade.retrieve_user.assert_called_once_with("ABCDEFG2F")
-    mock_facade.delete_user.assert_called_once_with("U0G9QF9C6")
-    mock_bot.send_to_channel.assert_called_once_with(message, "C0LAN2Q65")
-
-
-def test_handle_delete_not_admin():
-    """Test user command delete where user is not admin."""
-    mock_bot = mock.MagicMock(Bot)
-    mock_facade = mock.MagicMock(DBFacade)
-    testcommand = UserCommand(mock_facade, mock_bot)
-    user = User("ABCDEFG2F")
-    user.set_permissions_level(Permissions.member)
-    mock_facade.retrieve_user.return_value = user
-    testcommand.handle("user delete U0G9QF9C6", "ABCDEFG2F", "C0LAN2Q65")
-    mock_facade.retrieve_user.assert_called_once_with("ABCDEFG2F")
-    message = "You do not have the sufficient " \
-              "permission level for this command!"
-    mock_bot.send_to_channel.assert_called_once_with(message, "C0LAN2Q65")
-    mock_facade.delete_user.assert_not_called()
-
-
-def test_handle_delete_lookup_error():
-    """Test user command delete parser."""
-    mock_bot = mock.MagicMock(Bot)
-    mock_facade = mock.MagicMock(DBFacade)
-    testcommand = UserCommand(mock_facade, mock_bot)
-    user = User("ABCDEFG2F")
-    user.set_permissions_level(Permissions.admin)
-    mock_facade.retrieve_user.return_value = user
-    mock_facade.delete_user.side_effect = LookupError
-    testcommand.handle("user delete U0G9QF9C6", "ABCDEFG2F", "C0LAN2Q65")
-    mock_facade.retrieve_user.assert_called_once_with("ABCDEFG2F")
-    mock_facade.delete_user.assert_called_once_with("U0G9QF9C6")
-    mock_bot.send_to_channel.\
-        assert_called_once_with(UserCommand.lookup_error, "C0LAN2Q65")
-
-
-def test_handle_edit_name():
-    """Test user command edit parser with one field."""
-    mock_facade = mock.MagicMock(DBFacade)
-    mock_bot = mock.MagicMock(Bot)
-    testcommand = UserCommand(mock_facade, mock_bot)
-    assert testcommand.handle("user edit --name rob", "U0G9QF9C6",
-                              "C0LAN2Q65") == "user edited: name: rob, "
-
-
-def test_handle_edit():
-    """Test user command edit parser with all fields."""
-    result = "user edited: member: id, name: rob, email: rob@rob.com, " \
-             "position: dev, github: rob@.github.com, major: Computer " \
-             "Science, bio: Im a human"
-    mock_facade = mock.MagicMock(DBFacade)
-    mock_bot = mock.MagicMock(Bot)
-    testcommand = UserCommand(mock_facade, mock_bot)
-    assert testcommand.handle("user edit --name rob --member id "
-                              "--email rob@rob.com --pos "
-                              "dev --github rob@.github.com "
-                              "--major 'Computer Science' "
-                              "--bio 'Im a human'",
-                              "U0G9QF9C6", "C0LAN2Q65") == result
+    def test_handle_edit(self):
+        """Test user command edit parser with all fields."""
+        result = "user edited: member: id, name: rob, email: rob@rob.com, " \
+                 "position: dev, github: rob@.github.com, major: Computer " \
+                 "Science, bio: Im a human"
+        assert self.testcommand.handle(
+                                  "user edit --name rob --member id "
+                                  "--email rob@rob.com --pos "
+                                  "dev --github rob@.github.com "
+                                  "--major 'Computer Science' "
+                                  "--bio 'Im a human'",
+                                  "U0G9QF9C6", "C0LAN2Q65") == result

--- a/tests/command/commands/user_test.py
+++ b/tests/command/commands/user_test.py
@@ -26,6 +26,13 @@ def test_handle_bad_args():
     assert testcommand.handle('user geese', "U0G9QF9C6") == UserCommand.help
 
 
+def test_handle_bad_optional_args():
+    """Test user edit with invalid optional arguments."""
+    testcommand = UserCommand()
+    assert testcommand.handle('user edit --biology stuff', "U0G9QF9C6")\
+        == UserCommand.help
+
+
 def test_handle_view():
     """Test user command view parser and handle method."""
     user_id = "U0G9QF9C6"

--- a/tests/command/core_test.py
+++ b/tests/command/core_test.py
@@ -1,10 +1,14 @@
 """Test the core event handler."""
 from unittest import mock
 from command.core import Core
+from bot.bot import Bot
+from db.facade import DBFacade
 
 
 def test_handle_invalid_mention():
     """Test the instance of handle_app_mention being called inappropriately."""
+    mock_facade = mock.MagicMock(DBFacade)
+    mock_bot = mock.MagicMock(Bot)
     event = {
         "token": "XXYYZZ",
         "team_id": "TXXXXXXXX",
@@ -22,12 +26,14 @@ def test_handle_invalid_mention():
         "event_id": "Ev08MFMKH6",
         "event_time": 1234567890
     }
-    core = Core()
+    core = Core(mock_bot, mock_facade)
     assert core.handle_app_mention(event) == 0
 
 
 def test_handle_invalid_command():
     """Test that invalid commands are being handled appropriately."""
+    mock_facade = mock.MagicMock(DBFacade)
+    mock_bot = mock.MagicMock(Bot)
     event = {
         "token": "XXYYZZ",
         "team_id": "TXXXXXXXX",
@@ -45,13 +51,15 @@ def test_handle_invalid_command():
         "event_id": "Ev08MFMKH6",
         "event_time": 123456789
     }
-    core = Core()
+    core = Core(mock_bot, mock_facade)
     assert core.handle_app_mention(event) == -1
 
 
 @mock.patch('command.core.UserCommand')
 def test_handle_user_command(MockUserCommand):
     """Test that UserCommand.handle is called appropriately."""
+    mock_facade = mock.MagicMock(DBFacade)
+    mock_bot = mock.MagicMock(Bot)
     event = {
         "token": "XXYYZZ",
         "team_id": "TXXXXXXXX",
@@ -69,7 +77,8 @@ def test_handle_user_command(MockUserCommand):
         "event_id": "Ev08MFMKH6",
         "event_time": 1234567890
     }
-    core = Core()
+    core = Core(mock_bot, mock_facade)
     assert core.handle_app_mention(event) == 1
     MockUserCommand.\
-        return_value.handle.assert_called_once_with("user name", "U061F7AUR")
+        return_value.handle.\
+        assert_called_once_with("user name", "U061F7AUR", "C0LAN2Q65")


### PR DESCRIPTION
# Pull Request

## Description
User command view and delete commands implementation and tests
Changed core and usercommand constructors to include bot and database facade parameters

## Testing

If testing this change requires extra setup, please document it here:

## Ticket(s)

Affects #64 

(Create a copy of that line for each Github Issue affected,
and replace "Affects" with "Closes" if merging this will close the relevant ticket.)
