### PR TITLE
Neutralize the Travis Race (condition)

### DIFF
--- a/scripts/download_dynamodb_and_run.sh
+++ b/scripts/download_dynamodb_and_run.sh
@@ -17,3 +17,4 @@ cd DynamoDB
 java -Djava.library.path=./DynamoDBLocal_lib -jar DynamoDBLocal.jar -sharedDb &
 cd ..
 
+sleep 3


### PR DESCRIPTION
# Pull Request

## Description

Build gives 3 seconds of leeway to allow for local dynamodb initialization.

## Testing

Check travis. Just check it to see if it always recognizes that dynamodb is running. Travis will now unfortunately run 3 seconds slower as a result.

## Ticket(s)

Closes #102.